### PR TITLE
docs: document auth env vars, docker-compose examples, and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ services:
     - ./data:/app/data 
   environment: 
     - STORE=json 
+    # Optional: password-protect the bookmarks API
+    - FRIBROWSE_PASSWORD=StrongPassword # CHANGE or remove to disable auth
+    - FRIBROWSE_SECURE_COOKIE=false # Set to true if using HTTPS
+    - FRIBROWSE_ORIGIN=http://localhost:3002 # Restrict CORS to this origin
 ```
 
 #### For use with CouchDB
@@ -51,19 +55,36 @@ services:
       COUCH_USER: Username # CHANGE
       COUCH_PASS: StrongPassword # CHANGE
       COUCH_DB: fribrowse # Can be changed
+      # Optional: password-protect the bookmarks API
+      FRIBROWSE_PASSWORD: StrongPassword # CHANGE or remove to disable auth
+      FRIBROWSE_SECURE_COOKIE: "false" # Set to "true" if using HTTPS
+      FRIBROWSE_ORIGIN: http://localhost:3002 # Restrict CORS to this origin
 ```
 
 ## Documentation
 
 Environment variables. If none are set, the API will fall back on JSON.
 
-| Variable    | Description     | Example                         |
-| ----------- | --------------- | ------------------------------- |
-| STORE       | Storage backend | `json` or `couchdb`             |
-| COUCH_URL   | CouchDB URL     | `http://database/url/here:5984` |
-| COUCH_USER  | Username        | `admin`                         |
-| COUCH_PASS  | Password        | `StrongPassword`                |
-| COUCH_DB    | Database name   | `fribrowse`                     |
+| Variable                | Description                                                                  | Example                         |
+| ----------------------- | ---------------------------------------------------------------------------- | ------------------------------- |
+| STORE                   | Storage backend                                                              | `json` or `couchdb`             |
+| COUCH_URL               | CouchDB URL                                                                  | `http://database/url/here:5984` |
+| COUCH_USER              | Username                                                                     | `admin`                         |
+| COUCH_PASS              | Password                                                                     | `StrongPassword`                |
+| COUCH_DB                | Database name                                                                | `fribrowse`                     |
+| PORT                    | HTTP port the server listens on. Defaults to `3002`.                         | `3002`                          |
+| FRIBROWSE_PASSWORD      | Password to protect the bookmarks API. When set, a valid session is required.| `StrongPassword`                |
+| FRIBROWSE_SECURE_COOKIE | Set to `true` when serving over HTTPS to mark the session cookie as Secure.  | `true`                          |
+| FRIBROWSE_ORIGIN        | Allowed CORS origin for cross-origin access with credentials.                | `http://localhost:3002`         |
+
+### API Endpoints
+
+Authentication endpoints are only active when `FRIBROWSE_PASSWORD` is set.
+
+| Method | Endpoint      | Description                                                                 |
+| ------ | ------------- | --------------------------------------------------------------------------- |
+| POST   | `/api/login`  | Authenticate with `{"password": "..."}`. Sets a session cookie on success. |
+| POST   | `/api/logout` | Invalidate the current session cookie.                                      |
 
 [Development Setup](development.md)
 


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/Frimi01/Fribrowse/sessions/8bb3e17e-2ce8-48c3-8590-3993361ad9a2