### PR TITLE
Feature/authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ services:
     - ./data:/app/data 
   environment: 
     - STORE=json 
+    # Optional: password-protect the bookmarks API
+    - FRIBROWSE_PASSWORD=StrongPassword # CHANGE or remove to disable auth
+    - FRIBROWSE_SECURE_COOKIE=false # Set to true if using HTTPS
+    - FRIBROWSE_ORIGIN=http://localhost:3002 # Restrict CORS to this origin
 ```
 
 #### For use with CouchDB
@@ -51,19 +55,36 @@ services:
       COUCH_USER: Username # CHANGE
       COUCH_PASS: StrongPassword # CHANGE
       COUCH_DB: fribrowse # Can be changed
+      # Optional: password-protect the bookmarks API
+      FRIBROWSE_PASSWORD: StrongPassword # CHANGE or remove to disable auth
+      FRIBROWSE_SECURE_COOKIE: "false" # Set to "true" if using HTTPS
+      FRIBROWSE_ORIGIN: http://localhost:3002 # Restrict CORS to this origin
 ```
 
 ## Documentation
 
 Environment variables. If none are set, the API will fall back on JSON.
 
-| Variable    | Description     | Example                         |
-| ----------- | --------------- | ------------------------------- |
-| STORE       | Storage backend | `json` or `couchdb`             |
-| COUCH_URL   | CouchDB URL     | `http://database/url/here:5984` |
-| COUCH_USER  | Username        | `admin`                         |
-| COUCH_PASS  | Password        | `StrongPassword`                |
-| COUCH_DB    | Database name   | `fribrowse`                     |
+| Variable                | Description                                                                  | Example                         |
+| ----------------------- | ---------------------------------------------------------------------------- | ------------------------------- |
+| STORE                   | Storage backend                                                              | `json` or `couchdb`             |
+| COUCH_URL               | CouchDB URL                                                                  | `http://database/url/here:5984` |
+| COUCH_USER              | Username                                                                     | `admin`                         |
+| COUCH_PASS              | Password                                                                     | `StrongPassword`                |
+| COUCH_DB                | Database name                                                                | `fribrowse`                     |
+| PORT                    | HTTP port the server listens on. Defaults to `3002`.                         | `3002`                          |
+| FRIBROWSE_PASSWORD      | Password to protect the bookmarks API. When set, a valid session is required.| `StrongPassword`                |
+| FRIBROWSE_SECURE_COOKIE | Set to `true` when serving over HTTPS to mark the session cookie as Secure.  | `true`                          |
+| FRIBROWSE_ORIGIN        | Allowed CORS origin for cross-origin access with credentials.                | `http://localhost:3002`         |
+
+### API Endpoints
+
+Authentication endpoints are only active when `FRIBROWSE_PASSWORD` is set.
+
+| Method | Endpoint      | Description                                                                 |
+| ------ | ------------- | --------------------------------------------------------------------------- |
+| POST   | `/api/login`  | Authenticate with `{"password": "..."}`. Sets a session cookie on success. |
+| POST   | `/api/logout` | Invalidate the current session cookie.                                      |
 
 [Development Setup](development.md)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Environment variables. If none are set, the API will fall back on JSON.
 | COUCH_PASS              | Password                                                                     | `StrongPassword`                |
 | COUCH_DB                | Database name                                                                | `fribrowse`                     |
 | PORT                    | HTTP port the server listens on. Defaults to `3002`.                         | `3002`                          |
-| FRIBROWSE_PASSWORD      | Shared identity token to protect the bookmarks API. When set, a valid session is required.| `StrongToken`                   |
+| FRIBROWSE_PASSWORD      | Shared access token (submitted in the `password` field) to protect the bookmarks API. When set, a valid session is required.| `StrongToken`                   |
 | FRIBROWSE_SECURE_COOKIE | Set to `true` when serving over HTTPS to mark the session cookie as Secure.  | `true`                          |
 | FRIBROWSE_ORIGIN        | Allowed CORS origin for cross-origin access with credentials.                | `http://localhost:3002`         |
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ services:
     - ./data:/app/data 
   environment: 
     - STORE=json 
-    # Optional: password-protect the bookmarks API
-    - FRIBROWSE_PASSWORD=StrongPassword # CHANGE or remove to disable auth
+    # Optional: token-protect the bookmarks API
+    - FRIBROWSE_TOKEN=StrongToken # CHANGE or remove to disable auth
     - FRIBROWSE_SECURE_COOKIE=false # Set to true if using HTTPS
     - FRIBROWSE_ORIGIN=http://localhost:3002 # Restrict CORS to this origin
 ```
@@ -55,8 +55,8 @@ services:
       COUCH_USER: Username # CHANGE
       COUCH_PASS: StrongPassword # CHANGE
       COUCH_DB: fribrowse # Can be changed
-      # Optional: password-protect the bookmarks API
-      FRIBROWSE_PASSWORD: StrongPassword # CHANGE or remove to disable auth
+      # Optional: token-protect the bookmarks API
+      FRIBROWSE_TOKEN: StrongToken # CHANGE or remove to disable auth
       FRIBROWSE_SECURE_COOKIE: "false" # Set to "true" if using HTTPS
       FRIBROWSE_ORIGIN: http://localhost:3002 # Restrict CORS to this origin
 ```
@@ -73,17 +73,17 @@ Environment variables. If none are set, the API will fall back on JSON.
 | COUCH_PASS              | Password                                                                     | `StrongPassword`                |
 | COUCH_DB                | Database name                                                                | `fribrowse`                     |
 | PORT                    | HTTP port the server listens on. Defaults to `3002`.                         | `3002`                          |
-| FRIBROWSE_PASSWORD      | Shared access token (submitted in the `password` field) to protect the bookmarks API. When set, a valid session is required.| `StrongToken`                   |
+| FRIBROWSE_TOKEN         | Shared access token for bookmark API; basic password-style protection, not fully secure. | `StrongToken`                   |
 | FRIBROWSE_SECURE_COOKIE | Set to `true` when serving over HTTPS to mark the session cookie as Secure.  | `true`                          |
 | FRIBROWSE_ORIGIN        | Allowed CORS origin for cross-origin access with credentials.                | `http://localhost:3002`         |
 
 ### API Endpoints
 
-Authentication endpoints are only active when `FRIBROWSE_PASSWORD` is set.
+Authentication endpoints are only active when `FRIBROWSE_TOKEN` is set.
 
 | Method | Endpoint      | Description                                                                 |
 | ------ | ------------- | --------------------------------------------------------------------------- |
-| POST   | `/api/login`  | Authenticate with `{"password": "..."}` using the configured shared token. Sets a session cookie on success. |
+| POST   | `/api/login`  | Authenticate with `{"token": "..."}` using the configured shared token. Sets a session cookie on success. |
 | POST   | `/api/logout` | Invalidate the current session cookie.                                      |
 
 [Development Setup](development.md)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Environment variables. If none are set, the API will fall back on JSON.
 | COUCH_PASS              | Password                                                                     | `StrongPassword`                |
 | COUCH_DB                | Database name                                                                | `fribrowse`                     |
 | PORT                    | HTTP port the server listens on. Defaults to `3002`.                         | `3002`                          |
-| FRIBROWSE_PASSWORD      | Password to protect the bookmarks API. When set, a valid session is required.| `StrongPassword`                |
+| FRIBROWSE_PASSWORD      | Shared identity token to protect the bookmarks API. When set, a valid session is required.| `StrongToken`                   |
 | FRIBROWSE_SECURE_COOKIE | Set to `true` when serving over HTTPS to mark the session cookie as Secure.  | `true`                          |
 | FRIBROWSE_ORIGIN        | Allowed CORS origin for cross-origin access with credentials.                | `http://localhost:3002`         |
 
@@ -83,7 +83,7 @@ Authentication endpoints are only active when `FRIBROWSE_PASSWORD` is set.
 
 | Method | Endpoint      | Description                                                                 |
 | ------ | ------------- | --------------------------------------------------------------------------- |
-| POST   | `/api/login`  | Authenticate with `{"password": "..."}`. Sets a session cookie on success. |
+| POST   | `/api/login`  | Authenticate with `{"password": "..."}` using the configured shared token. Sets a session cookie on success. |
 | POST   | `/api/logout` | Invalidate the current session cookie.                                      |
 
 [Development Setup](development.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,7 +24,7 @@ services:
       # This is simply an additional layer of security to prevent exposure of data.
       # You can remove the two variables below if you know what you're doing.
       FRIBROWSE_SECURE_COOKIE: "false" # Set to "true" if using HTTPS
-      FRIBROWSE_PASSWORD: "password123" # Change this
+      FRIBROWSE_TOKEN: "token123" # Change this
 
       # Storage mode:
       # - couchdb

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,14 @@ services:
     ports:
       - "3002:3002"
     environment:
+      FRIBROWSE_ORIGIN: http://localhost
+
+      # For production, you should deploy behind a reverse proxy or service that handles authentication properly.
+      # This is simply an additional layer of security to prevent exposure of data.
+      # You can remove the two variables below if you know what you're doing.
+      FRIBROWSE_SECURE_COOKIES: "false" # Set to "true" if using HTTPS
+      FRIBROWSE_PASSWORD: "password123" # Change this
+
       # Storage mode:
       # - couchdb
       # - json (stores bookmarks in a local JSON file, no database required)
@@ -73,4 +81,5 @@ services:
 #################Volumes#####################################
 volumes:
   couchdb-data:
+
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,7 +18,7 @@ services:
     ports:
       - "3002:3002"
     environment:
-      FRIBROWSE_ORIGIN: http://localhost
+      FRIBROWSE_ORIGIN: http://localhost:3002
 
       # For production, you should deploy behind a reverse proxy or service that handles authentication properly.
       # This is simply an additional layer of security to prevent exposure of data.

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,7 +23,7 @@ services:
       # For production, you should deploy behind a reverse proxy or service that handles authentication properly.
       # This is simply an additional layer of security to prevent exposure of data.
       # You can remove the two variables below if you know what you're doing.
-      FRIBROWSE_SECURE_COOKIES: "false" # Set to "true" if using HTTPS
+      FRIBROWSE_SECURE_COOKIE: "false" # Set to "true" if using HTTPS
       FRIBROWSE_PASSWORD: "password123" # Change this
 
       # Storage mode:

--- a/public/core/BookmarkManager.js
+++ b/public/core/BookmarkManager.js
@@ -74,7 +74,18 @@ export class BookmarkManager {
 				this.authenticated = true;
 			} else {
 				const current = await this.#fetchCurrentState();
-				this.revision = current.revision;
+				if (current == null) {
+					this.authenticated = false;
+					this.revision = 0;
+					notification(
+						"Importing bookmarks without current sync state.",
+						"Could not fetch the current bookmark revision because authentication is required or the server state is unavailable. The imported bookmarks were loaded locally with revision 0. Log in before syncing to avoid overwriting server data.",
+						true,
+						true
+					);
+				} else {
+					this.revision = current.revision ?? 0;
+				}
 				json = data;
 			}
 

--- a/public/core/BookmarkManager.js
+++ b/public/core/BookmarkManager.js
@@ -38,8 +38,8 @@ export class BookmarkManager {
 						return this.loadBookmarks(data);
 					}
 
-					userMessage = "Authentication required to load bookmarks.";
-					technicalDetails = "Please log in to access your bookmarks.\nStatus: 401 Unauthorized";
+					const userMessage = "Authentication required to load bookmarks.";
+					const technicalDetails = "Please log in to access your bookmarks.\nStatus: 401 Unauthorized";
 					notification(userMessage, technicalDetails, true, true);
 					throw new Error("Unauthorized");
 				}

--- a/public/core/BookmarkManager.js
+++ b/public/core/BookmarkManager.js
@@ -7,20 +7,42 @@ export class BookmarkManager {
 
 		// JSON
 		this.version = version;
-		this.revision = 0;
+		this.revision = -1; // Prevents accidental overwrites on data initialized by 0.
 		this.bookmarks = [];
 
 		this.saving = false;
 		this.pendingSave = false;
 		this.unsynced = false;
 		this.createSyncButton();
+
+		this.authenticated = false;
+		this.onAuthRequired = null; 
 	}
 
 	async loadBookmarks(data = null) {
 		try {
 			let json;
 			if (data == null) {
-				const res = await fetch(`${this.api}/bookmarks`);
+				const res = await fetch(`${this.api}/bookmarks`, {
+					method: "GET",
+					headers: { "Content-Type": "application/json" },
+					credentials: "include"
+				});
+
+				if (res.status === 401) {
+					console.log("Authentication required");
+					this.authenticated = false;
+
+					const success = await this.handleUnauthorized();
+					if (success) {
+						return this.loadBookmarks(data);
+					}
+
+					userMessage = "Authentication required to load bookmarks.";
+					technicalDetails = "Please log in to access your bookmarks.\nStatus: 401 Unauthorized";
+					notification(userMessage, technicalDetails, true, true);
+					throw new Error("Unauthorized");
+				}
 
 				if (!res.ok) {
 					console.error("Error loading bookmarks:", res);
@@ -34,6 +56,7 @@ export class BookmarkManager {
 						notification(userMessage, technicalDetails, false, false);
 						this.revision = 0;
 						this.bookmarks = [];
+						this.authenticated = true;
 						return [];
 					} else if (res.status === 500) {
 						userMessage = "Server error while loading bookmarks.";
@@ -48,13 +71,12 @@ export class BookmarkManager {
 					return [];
 				}
 				json = await res.json();
+				this.authenticated = true;
 			} else {
 				const current = await this.#fetchCurrentState();
 				this.revision = current.revision;
 				json = data;
 			}
-
-
 
 			// Legacy: server returned a bare array before envelope format was introduced.
 			if (Array.isArray(json)) {
@@ -83,7 +105,17 @@ export class BookmarkManager {
 
 	async #fetchCurrentState() {
 		try {
-			const res = await fetch(`${this.api}/bookmarks`);
+			const res = await fetch(`${this.api}/bookmarks`, {
+				method: "GET",
+				headers: { "Content-Type": "application/json" },
+				credentials: "include"
+			});
+			
+			if (res.status === 401) {
+				this.authenticated = false;
+				return null;
+			}
+			
 			if (!res.ok) return null;
 			return await res.json();
 		} catch {
@@ -102,6 +134,21 @@ export class BookmarkManager {
 
 		while (true) {
 			try {
+				// Check if we lost authentication
+				if (!this.authenticated) {
+					const success = await this.handleUnauthorized();
+					if (!success) {
+						this.unsync();
+						notification(
+							"Authentication required to save bookmarks.",
+							"Please log in to sync your changes.",
+							true,
+							true
+						);
+						break;
+					}
+				}
+
 				const current = await this.#fetchCurrentState();
 
 				if (current !== null && current.revision !== undefined && current.revision !== this.revision) {
@@ -124,12 +171,31 @@ export class BookmarkManager {
 				const res = await fetch(`${this.api}/bookmarks`, {
 					method: "PUT",
 					headers: { "Content-Type": "application/json" },
+					credentials: "include",
 					body: JSON.stringify({
 						revision: this.revision + 1,
 						version: this.version,
 						data: this.bookmarks
 					}),
 				});
+
+				if (res.status === 401) {
+					console.log("Authentication required for save");
+					this.authenticated = false;
+					const success = await this.handleUnauthorized();
+					if (!success) {
+						this.unsync();
+						notification(
+							"Authentication required to save bookmarks.",
+							"Please log in to sync your changes.",
+							true,
+							true
+						);
+						break;
+					}
+					// Retry after successful auth
+					continue;
+				}
 
 				if (!res.ok) {
 					console.error("Failed to save bookmarks:", res);
@@ -258,6 +324,63 @@ export class BookmarkManager {
 				return this.bookmarks;
 			default:
 				notification("Migration failed, manual reformatting required.", "oldVersion not identifiable.", true, true);
+		}
+	}
+
+	async handleUnauthorized() {
+		const password = prompt("Enter password to access bookmarks:");
+
+		if (!password) {
+			console.log("User cancelled authentication");
+			return false;
+		}
+
+		try {
+			const res = await fetch(`${this.api}/login`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				credentials: "include",
+				body: JSON.stringify({ password })
+			});
+
+			if (!res.ok) {
+				alert("Login failed. Please check your password.");
+				console.error("Login failed with status:", res.status);
+				return false;
+			}
+
+			console.log("Login successful");
+			this.authenticated = true;
+			
+			// Trigger callback if set
+			if (this.onAuthRequired) {
+				this.onAuthRequired();
+			}
+			
+			return true;
+
+		} catch (err) {
+			console.error("Login error:", err);
+			alert("Login failed due to connection error.");
+			return false;
+		}
+	}
+
+	// Unused for now
+	async logout() {
+		try {
+			const res = await fetch(`${this.api}/logout`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				credentials: "include"
+			});
+
+			if (res.ok) {
+				this.authenticated = false;
+				console.log("Logged out successfully");
+			}
+		} catch (err) {
+			console.error("Logout error:", err);
 		}
 	}
 

--- a/public/core/BookmarkManager.js
+++ b/public/core/BookmarkManager.js
@@ -339,9 +339,9 @@ export class BookmarkManager {
 	}
 
 	async handleUnauthorized() {
-		const password = prompt("Enter password to access bookmarks:");
+		const token = prompt("Enter access token to access bookmarks:");
 
-		if (!password) {
+		if (!token) {
 			console.log("User cancelled authentication");
 			return false;
 		}
@@ -351,11 +351,11 @@ export class BookmarkManager {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				credentials: "include",
-				body: JSON.stringify({ password })
+				body: JSON.stringify({ token })
 			});
 
 			if (!res.ok) {
-				alert("Login failed. Please check your password.");
+				alert("Login failed. Please check your access token.");
 				console.error("Login failed with status:", res.status);
 				return false;
 			}

--- a/server.go
+++ b/server.go
@@ -28,6 +28,7 @@ const (
 	maxAuthBodyBytes = 1024
 	shutdownTimeout  = 5 * time.Second
 	sessionDuration  = 30 * 24 * time.Hour
+	sessionMaxAge    = int(sessionDuration / time.Second)
 )
 
 const (
@@ -529,15 +530,16 @@ func loginHandler() http.HandlerFunc {
 
 		r.Body = http.MaxBytesReader(w, r.Body, maxAuthBodyBytes)
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			http.Error(w, "Invalid request", http.StatusBadRequest)
 			return
 		}
 
 		expectedPassword := os.Getenv("FRIBROWSE_PASSWORD")
-		if expectedPassword == "" {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
 		if subtle.ConstantTimeCompare([]byte(body.Password), []byte(expectedPassword)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
@@ -561,7 +563,7 @@ func loginHandler() http.HandlerFunc {
 			HttpOnly: true,
 			Secure:   secure,
 			SameSite: http.SameSiteLaxMode,
-			MaxAge:   int(sessionDuration / time.Second),
+			MaxAge:   sessionMaxAge,
 		})
 
 		w.WriteHeader(http.StatusOK)

--- a/server.go
+++ b/server.go
@@ -621,15 +621,12 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		now := time.Now()
 		sessionsMu.RLock()
 		s, ok := sessions[cookie.Value]
+		if !ok || now.After(s.expires) {
+			sessionsMu.RUnlock()
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 		sessionsMu.RUnlock()
-		if !ok {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		if now.After(s.expires) {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
 
 		next(w, r)
 	}

--- a/server.go
+++ b/server.go
@@ -618,10 +618,12 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
+		now := time.Now()
 		sessionsMu.RLock()
 		s, ok := sessions[cookie.Value]
+		expired := ok && now.After(s.expires)
 		sessionsMu.RUnlock()
-		if !ok || time.Now().After(s.expires) {
+		if !ok || expired {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/server.go
+++ b/server.go
@@ -621,9 +621,12 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		now := time.Now()
 		sessionsMu.RLock()
 		s, ok := sessions[cookie.Value]
-		expired := ok && now.After(s.expires)
 		sessionsMu.RUnlock()
-		if !ok || expired {
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if now.After(s.expires) {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/server.go
+++ b/server.go
@@ -27,6 +27,7 @@ const (
 	maxRequestBodyMB = 10
 	maxAuthBodyBytes = 1024
 	shutdownTimeout  = 5 * time.Second
+	sessionDuration  = 30 * 24 * time.Hour
 )
 
 const (
@@ -533,6 +534,10 @@ func loginHandler() http.HandlerFunc {
 		}
 
 		expectedPassword := os.Getenv("FRIBROWSE_PASSWORD")
+		if expectedPassword == "" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		if subtle.ConstantTimeCompare([]byte(body.Password), []byte(expectedPassword)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
@@ -545,7 +550,7 @@ func loginHandler() http.HandlerFunc {
 			return
 		}
 		sessionsMu.Lock()
-		sessions[sessionID] = session{expires: time.Now().Add(24 * 30 * time.Hour)}
+		sessions[sessionID] = session{expires: time.Now().Add(sessionDuration)}
 		sessionsMu.Unlock()
 
 		secure := os.Getenv("FRIBROWSE_SECURE_COOKIE") == "true"
@@ -556,7 +561,7 @@ func loginHandler() http.HandlerFunc {
 			HttpOnly: true,
 			Secure:   secure,
 			SameSite: http.SameSiteLaxMode,
-			MaxAge:   60 * 60 * 24 * 30,
+			MaxAge:   int(sessionDuration / time.Second),
 		})
 
 		w.WriteHeader(http.StatusOK)

--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -18,11 +19,11 @@ import (
 )
 
 const (
-	defaultPort       = "3002"
-	bookmarksFile     = "./bookmarks.json"
-	backupDir         = "./backups"
-	maxRequestBodyMB  = 10
-	shutdownTimeout   = 5 * time.Second
+	defaultPort      = "3002"
+	bookmarksFile    = "./bookmarks.json"
+	backupDir        = "./backups"
+	maxRequestBodyMB = 10
+	shutdownTimeout  = 5 * time.Second
 )
 
 const (
@@ -38,6 +39,16 @@ type BookmarkStore interface {
 
 type JSONStore struct {
 	path string
+}
+
+type session struct {
+	expires time.Time
+}
+
+var sessions = map[string]session{}
+
+func isAuthEnabled() bool {
+	return os.Getenv("FRIBROWSE_PASSWORD") != ""
 }
 
 func (s *JSONStore) Load() ([]byte, error) {
@@ -56,13 +67,14 @@ func (s *JSONStore) Load() ([]byte, error) {
 	return data, nil
 }
 
+// TODO: OS respective atomic save
 func (s *JSONStore) Save(data []byte) error {
 	err := os.WriteFile(s.path, data, 0644)
 	if err != nil {
 		log.Printf("%sFailed to write JSON file: %v", logError, err)
 		return err
 	}
-	
+
 	log.Printf("%sSaved %d bytes to JSON file", logInfo, len(data))
 	return nil
 }
@@ -259,12 +271,12 @@ func (c *CouchStore) ensureDatabase() error {
 		log.Printf("%sCreated CouchDB database: %s", logInfo, c.dbName)
 		return nil
 	}
-	
+
 	if res.StatusCode == http.StatusPreconditionFailed {
 		log.Printf("%sCouchDB database already exists: %s", logInfo, c.dbName)
 		return nil
 	}
-	
+
 	body, _ := io.ReadAll(res.Body)
 	log.Printf("%sFailed to create database - Status: %d, Error: %s", logError, res.StatusCode, strings.TrimSpace(string(body)))
 	return fmtError(res.Status, body)
@@ -288,13 +300,13 @@ func main() {
 			os.Getenv("COUCH_PASS"),
 			os.Getenv("COUCH_DB"),
 		)
-		
+
 		log.Printf("%sUsing CouchDB storage", logInfo)
 		log.Printf("%sEnsuring database exists...", logInfo)
 		if err := couchStore.ensureDatabase(); err != nil {
 			log.Fatalf("%sFailed to ensure CouchDB database exists: %v", logError, err)
 		}
-		
+
 		store = couchStore
 	} else {
 		store = &JSONStore{path: bookmarksFile}
@@ -309,7 +321,7 @@ func main() {
 	<-stop
 
 	log.Printf("%sShutdown signal received, shutting down gracefully...", logInfo)
-	
+
 	// Create backup before shutdown
 	if os.Getenv("STORE") != "couchdb" {
 		backupJSON("lastServerShutdown")
@@ -318,36 +330,29 @@ func main() {
 	// Graceful shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
-	
+
 	if err := srv.Shutdown(ctx); err != nil {
 		log.Printf("%sServer shutdown error: %v", logError, err)
 	}
-	
+
 	log.Printf("%sServer stopped", logInfo)
 }
 
 func startServer(store BookmarkStore, port string) *http.Server {
 	mux := http.NewServeMux()
 
-	// Add CORS middleware for local development
-	corsMiddleware := func(next http.HandlerFunc) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-			
-			if r.Method == "OPTIONS" {
-				w.WriteHeader(http.StatusOK)
-				return
-			}
-			
-			next(w, r)
-		}
-	}
-
 	mux.Handle("/", http.FileServer(http.Dir("./public")))
-	mux.HandleFunc("/api/bookmarks", corsMiddleware(bookmarksHandler(store)))
-	mux.HandleFunc("/api/health", healthCheckHandler())
+
+	// Auth routes
+	mux.HandleFunc("/api/login", corsMiddleware(loginHandler()))
+	mux.HandleFunc("/api/logout", corsMiddleware(logoutHandler()))
+
+	// Protected routes
+	mux.HandleFunc("/api/bookmarks",
+		corsMiddleware(authMiddleware(bookmarksHandler(store))),
+	)
+
+	mux.HandleFunc("/api/health", corsMiddleware(healthCheckHandler()))
 
 	srv := &http.Server{
 		Addr:    port,
@@ -355,7 +360,7 @@ func startServer(store BookmarkStore, port string) *http.Server {
 	}
 
 	go func() {
-		log.Printf("%sServer running on http://localhost%s", logInfo, port)
+		log.Printf("%sServer running on port %s", logInfo, port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("%sServer failed to start: %v", logError, err)
 		}
@@ -413,10 +418,10 @@ func handleGetBookmarks(store BookmarkStore, w http.ResponseWriter, r *http.Requ
 
 func handleSaveBookmarks(store BookmarkStore, w http.ResponseWriter, r *http.Request) {
 	log.Printf("%s%s /bookmarks", logDebug, r.Method)
-	
+
 	// Limit request body size
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyMB*1024*1024)
-	
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Printf("%sFailed to read request body: %v", logError, err)
@@ -478,4 +483,135 @@ func backupJSON(label string) {
 
 func fmtError(status string, body []byte) error {
 	return fmt.Errorf("http error %s: %s", status, string(body))
+}
+
+// Auth
+func newSessionID() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic("failed to generate session ID")
+	}
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+func loginHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isAuthEnabled() {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		// Clean up expired sessions
+		now := time.Now()
+		for k, s := range sessions {
+			if now.After(s.expires) {
+				delete(sessions, k)
+			}
+		}
+
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var body struct {
+			Password string `json:"password"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "Invalid request", http.StatusBadRequest)
+			return
+		}
+
+		if body.Password != os.Getenv("FRIBROWSE_PASSWORD") {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		sessionID := newSessionID()
+		sessions[sessionID] = session{expires: time.Now().Add(24 * 30 * time.Hour)}
+
+		secure := os.Getenv("FRIBROWSE_SECURE_COOKIE") == "true"
+		http.SetCookie(w, &http.Cookie{
+			Name:     "session",
+			Value:    sessionID,
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   60 * 60 * 24 * 30,
+		})
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func logoutHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isAuthEnabled() {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		cookie, err := r.Cookie("session")
+		if err == nil {
+			delete(sessions, cookie.Value)
+		}
+
+		secure := os.Getenv("FRIBROWSE_SECURE_COOKIE") == "true"
+		http.SetCookie(w, &http.Cookie{
+			Name:     "session",
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   -1, // delete immediately
+		})
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isAuthEnabled() {
+			next(w, r)
+			return
+		}
+
+		cookie, err := r.Cookie("session")
+		if err != nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		s, ok := sessions[cookie.Value]
+		if !ok || time.Now().After(s.expires) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		next(w, r)
+	}
+}
+
+func corsMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		origin := os.Getenv("FRIBROWSE_ORIGIN")
+
+		if origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		}
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next(w, r)
+	}
 }

--- a/server.go
+++ b/server.go
@@ -56,7 +56,7 @@ var (
 )
 
 func isAuthEnabled() bool {
-	return os.Getenv("FRIBROWSE_PASSWORD") != ""
+	return os.Getenv("FRIBROWSE_TOKEN") != ""
 }
 
 func (s *JSONStore) Load() ([]byte, error) {
@@ -515,7 +515,7 @@ func loginHandler() http.HandlerFunc {
 		}
 
 		var body struct {
-			Password string `json:"password"`
+			Token string `json:"token"`
 		}
 
 		r.Body = http.MaxBytesReader(w, r.Body, maxAuthBodyBytes)
@@ -529,13 +529,13 @@ func loginHandler() http.HandlerFunc {
 			return
 		}
 
-		expectedPassword := os.Getenv("FRIBROWSE_PASSWORD")
-		if expectedPassword == "" {
+		expectedToken := os.Getenv("FRIBROWSE_TOKEN")
+		if expectedToken == "" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		if subtle.ConstantTimeCompare([]byte(body.Password), []byte(expectedPassword)) != 1 {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		if subtle.ConstantTimeCompare([]byte(body.Token), []byte(expectedToken)) != 1 {
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
 			return
 		}
 

--- a/server.go
+++ b/server.go
@@ -509,16 +509,6 @@ func loginHandler() http.HandlerFunc {
 			return
 		}
 
-		// Clean up expired sessions
-		now := time.Now()
-		sessionsMu.Lock()
-		for k, s := range sessions {
-			if now.After(s.expires) {
-				delete(sessions, k)
-			}
-		}
-		sessionsMu.Unlock()
-
 		if r.Method != "POST" {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -540,6 +530,10 @@ func loginHandler() http.HandlerFunc {
 		}
 
 		expectedPassword := os.Getenv("FRIBROWSE_PASSWORD")
+		if expectedPassword == "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 		if subtle.ConstantTimeCompare([]byte(body.Password), []byte(expectedPassword)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
@@ -551,8 +545,15 @@ func loginHandler() http.HandlerFunc {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
+
+		now := time.Now()
 		sessionsMu.Lock()
-		sessions[sessionID] = session{expires: time.Now().Add(sessionDuration)}
+		for k, s := range sessions {
+			if now.After(s.expires) {
+				delete(sessions, k)
+			}
+		}
+		sessions[sessionID] = session{expires: now.Add(sessionDuration)}
 		sessionsMu.Unlock()
 
 		secure := os.Getenv("FRIBROWSE_SECURE_COOKIE") == "true"

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -23,6 +25,7 @@ const (
 	bookmarksFile    = "./bookmarks.json"
 	backupDir        = "./backups"
 	maxRequestBodyMB = 10
+	maxAuthBodyBytes = 1024
 	shutdownTimeout  = 5 * time.Second
 )
 
@@ -45,7 +48,10 @@ type session struct {
 	expires time.Time
 }
 
-var sessions = map[string]session{}
+var (
+	sessions   = map[string]session{}
+	sessionsMu sync.RWMutex
+)
 
 func isAuthEnabled() bool {
 	return os.Getenv("FRIBROWSE_PASSWORD") != ""
@@ -486,12 +492,12 @@ func fmtError(status string, body []byte) error {
 }
 
 // Auth
-func newSessionID() string {
+func newSessionID() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		panic("failed to generate session ID")
+		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(b)
+	return base64.URLEncoding.EncodeToString(b), nil
 }
 
 func loginHandler() http.HandlerFunc {
@@ -503,11 +509,13 @@ func loginHandler() http.HandlerFunc {
 
 		// Clean up expired sessions
 		now := time.Now()
+		sessionsMu.Lock()
 		for k, s := range sessions {
 			if now.After(s.expires) {
 				delete(sessions, k)
 			}
 		}
+		sessionsMu.Unlock()
 
 		if r.Method != "POST" {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -518,18 +526,27 @@ func loginHandler() http.HandlerFunc {
 			Password string `json:"password"`
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, maxAuthBodyBytes)
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "Invalid request", http.StatusBadRequest)
 			return
 		}
 
-		if body.Password != os.Getenv("FRIBROWSE_PASSWORD") {
+		expectedPassword := os.Getenv("FRIBROWSE_PASSWORD")
+		if subtle.ConstantTimeCompare([]byte(body.Password), []byte(expectedPassword)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		sessionID := newSessionID()
+		sessionID, err := newSessionID()
+		if err != nil {
+			log.Printf("%sFailed to generate session ID: %v", logError, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		sessionsMu.Lock()
 		sessions[sessionID] = session{expires: time.Now().Add(24 * 30 * time.Hour)}
+		sessionsMu.Unlock()
 
 		secure := os.Getenv("FRIBROWSE_SECURE_COOKIE") == "true"
 		http.SetCookie(w, &http.Cookie{
@@ -553,9 +570,16 @@ func logoutHandler() http.HandlerFunc {
 			return
 		}
 
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
 		cookie, err := r.Cookie("session")
 		if err == nil {
+			sessionsMu.Lock()
 			delete(sessions, cookie.Value)
+			sessionsMu.Unlock()
 		}
 
 		secure := os.Getenv("FRIBROWSE_SECURE_COOKIE") == "true"
@@ -586,7 +610,9 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
+		sessionsMu.RLock()
 		s, ok := sessions[cookie.Value]
+		sessionsMu.RUnlock()
 		if !ok || time.Now().After(s.expires) {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return

--- a/server_test.go
+++ b/server_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestGetBookmarks_FileNotFound verifies that GET /api/bookmarks returns 404
@@ -93,5 +94,86 @@ func TestJSONStore_Load_FileExists(t *testing.T) {
 	}
 	if string(data) != content {
 		t.Errorf("expected %q, got %q", content, string(data))
+	}
+}
+
+func TestLogoutHandler_MethodNotAllowed(t *testing.T) {
+	t.Setenv("FRIBROWSE_PASSWORD", "token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	rr := httptest.NewRecorder()
+
+	logoutHandler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+}
+
+func TestLoginAndLogoutFlow(t *testing.T) {
+	t.Setenv("FRIBROWSE_PASSWORD", "token")
+
+	sessionsMu.Lock()
+	sessions = map[string]session{}
+	sessionsMu.Unlock()
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(`{"password":"token"}`))
+	loginRR := httptest.NewRecorder()
+	loginHandler().ServeHTTP(loginRR, loginReq)
+
+	if loginRR.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, loginRR.Code)
+	}
+
+	loginResp := loginRR.Result()
+	loginCookie := loginResp.Cookies()[0]
+	if loginCookie.Name != "session" || loginCookie.Value == "" {
+		t.Fatalf("expected non-empty session cookie, got %q=%q", loginCookie.Name, loginCookie.Value)
+	}
+
+	sessionsMu.RLock()
+	_, ok := sessions[loginCookie.Value]
+	sessionsMu.RUnlock()
+	if !ok {
+		t.Fatalf("expected session to be stored after login")
+	}
+
+	logoutReq := httptest.NewRequest(http.MethodPost, "/api/logout", nil)
+	logoutReq.AddCookie(loginCookie)
+	logoutRR := httptest.NewRecorder()
+	logoutHandler().ServeHTTP(logoutRR, logoutReq)
+
+	if logoutRR.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, logoutRR.Code)
+	}
+
+	sessionsMu.RLock()
+	_, ok = sessions[loginCookie.Value]
+	sessionsMu.RUnlock()
+	if ok {
+		t.Fatalf("expected session to be deleted after logout")
+	}
+}
+
+func TestAuthMiddleware_UnauthorizedWithExpiredSession(t *testing.T) {
+	t.Setenv("FRIBROWSE_PASSWORD", "token")
+
+	sessionID := "expired-session"
+	sessionsMu.Lock()
+	sessions = map[string]session{
+		sessionID: {expires: time.Now().Add(-time.Hour)},
+	}
+	sessionsMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/bookmarks", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sessionID})
+	rr := httptest.NewRecorder()
+
+	authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -126,7 +126,11 @@ func TestLoginAndLogoutFlow(t *testing.T) {
 	}
 
 	loginResp := loginRR.Result()
-	loginCookie := loginResp.Cookies()[0]
+	cookies := loginResp.Cookies()
+	if len(cookies) == 0 {
+		t.Fatalf("expected at least one cookie in login response")
+	}
+	loginCookie := cookies[0]
 	if loginCookie.Name != "session" || loginCookie.Value == "" {
 		t.Fatalf("expected non-empty session cookie, got %q=%q", loginCookie.Name, loginCookie.Value)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -110,7 +110,7 @@ func TestJSONStore_Load_FileExists(t *testing.T) {
 }
 
 func TestLogoutHandler_MethodNotAllowed(t *testing.T) {
-	t.Setenv("FRIBROWSE_PASSWORD", "token")
+	t.Setenv("FRIBROWSE_TOKEN", "token")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
 	rr := httptest.NewRecorder()
@@ -123,10 +123,10 @@ func TestLogoutHandler_MethodNotAllowed(t *testing.T) {
 }
 
 func TestLoginAndLogoutFlow(t *testing.T) {
-	t.Setenv("FRIBROWSE_PASSWORD", "token")
+	t.Setenv("FRIBROWSE_TOKEN", "token")
 	resetSessions(t)
 
-	loginReq := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(`{"password":"token"}`))
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(`{"token":"token"}`))
 	loginRR := httptest.NewRecorder()
 	loginHandler().ServeHTTP(loginRR, loginReq)
 
@@ -169,7 +169,7 @@ func TestLoginAndLogoutFlow(t *testing.T) {
 }
 
 func TestAuthMiddleware_UnauthorizedWithExpiredSession(t *testing.T) {
-	t.Setenv("FRIBROWSE_PASSWORD", "token")
+	t.Setenv("FRIBROWSE_TOKEN", "token")
 	resetSessions(t)
 
 	sessionID := "expired-session"

--- a/server_test.go
+++ b/server_test.go
@@ -10,6 +10,18 @@ import (
 	"time"
 )
 
+func resetSessions(t *testing.T) {
+	t.Helper()
+	sessionsMu.Lock()
+	sessions = map[string]session{}
+	sessionsMu.Unlock()
+	t.Cleanup(func() {
+		sessionsMu.Lock()
+		sessions = map[string]session{}
+		sessionsMu.Unlock()
+	})
+}
+
 // TestGetBookmarks_FileNotFound verifies that GET /api/bookmarks returns 404
 // when the bookmarks.json file does not exist.
 func TestGetBookmarks_FileNotFound(t *testing.T) {
@@ -112,10 +124,7 @@ func TestLogoutHandler_MethodNotAllowed(t *testing.T) {
 
 func TestLoginAndLogoutFlow(t *testing.T) {
 	t.Setenv("FRIBROWSE_PASSWORD", "token")
-
-	sessionsMu.Lock()
-	sessions = map[string]session{}
-	sessionsMu.Unlock()
+	resetSessions(t)
 
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(`{"password":"token"}`))
 	loginRR := httptest.NewRecorder()
@@ -161,6 +170,7 @@ func TestLoginAndLogoutFlow(t *testing.T) {
 
 func TestAuthMiddleware_UnauthorizedWithExpiredSession(t *testing.T) {
 	t.Setenv("FRIBROWSE_PASSWORD", "token")
+	resetSessions(t)
 
 	sessionID := "expired-session"
 	sessionsMu.Lock()


### PR DESCRIPTION
Adds a temporary measure addressing the needs described in #6.

This is not meant to be the main source of autentication and security, but rather an extra measure of security added by default to stop accidental exposure of data if improperly configured, exposed, and other similar misconfigurations.

The change creates API endpoints at api/login and api/logout that manages cookie sessions to verify the identity of a user, and blocks unauthorized connections to api/bookmarks.